### PR TITLE
Added missing $post_id argument in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class Actress_CPT extends CPT_Core {
 	 * @since  0.1.0
 	 * @param  array  $column Array of registered column names
 	 */
-	public function columns_display( $column ) {
+	public function columns_display( $column, $post_id ) {
 		switch ( $column ) {
 			case 'headshot':
 				the_post_thumbnail();


### PR DESCRIPTION
It used to cause a PHP warning in the WP dashboard if just copy-pasted
