### PR TITLE
Revised name, require composer/installers for custom installation locations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "webdevstudios/cpt-core",
+    "name": "webdevstudios/cpt_core",
     "description": "WordPress Custom Post Type OO wrapper",
     "license": "GPLv2",
     "authors": [
@@ -16,8 +16,7 @@
     "support": {
         "issues": "https://github.com/WebDevStudios/CPT_Core/issues"
     },
-    "require": {},
-    "suggest": {
+    "require": {
         "composer/installers": "~1.0"
     },
     "autoload": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cpt_core",
+  "name": "webdevstudios/cpt_core",
   "version": "0.2.0",
   "description": "",
   "main": "Gruntfile.js",


### PR DESCRIPTION
I renamed the composer package name to webdevstudios/cpt_core to be more consistent with the git repository name and what's currently in https://github.com/WebDevStudios/Taxonomy_Core.

I could go either way with it if we want this to be installed as a plugin with the more normal dash-slug format: `wp-content/plugins/cpt-core`

If we go with dashes https://github.com/WebDevStudios/Taxonomy_Core should be updated as well.